### PR TITLE
Suggestions

### DIFF
--- a/examples/change-png-info.rs
+++ b/examples/change-png-info.rs
@@ -21,17 +21,21 @@ fn main() -> BoxResult<()> {
     let path = Path::new(r"./target/test_modified.png");
     let file = File::create(path)?;
     let ref mut w = BufWriter::new(file);
-    let mut encoder = png::Encoder::new_with_info(w, png_info.clone()); // With previous info
-                                                                        //Edit some attibute
+    // With previous info
+    let mut encoder = png::Encoder::new_with_info(w, png_info.clone());
+    // Edit some attribute
     encoder.add_text_chunk(
         "Testing tEXt".to_string(),
         "This is a tEXt chunk that will appear before the IDAT chunks.".to_string(),
     )?;
     //encoder.set_color(png::ColorType::Rgba);
     //encoder.set_depth(png::BitDepth::Eight);
-    //encoder.set_source_gamma(png::ScaledFloat::from_scaled(45455)); // 1.0 / 2.2, scaled by 100000
-    //encoder.set_source_gamma(png::ScaledFloat::new(1.0 / 2.2));     // 1.0 / 2.2, unscaled, but rounded
-    //let source_chromaticities = png::SourceChromaticities::new(     // Using unscaled instantiation here
+    //// 1.0 / 2.2, scaled by 100000
+    //encoder.set_source_gamma(png::ScaledFloat::from_scaled(45455));
+    //// 1.0 / 2.2, unscaled, but rounded
+    //encoder.set_source_gamma(png::ScaledFloat::new(1.0 / 2.2));
+    //// Using unscaled instantiation here
+    //let source_chromaticities = png::SourceChromaticities::new(
     //(0.31270, 0.32900),
     //(0.64000, 0.33000),
     //(0.30000, 0.60000),

--- a/examples/change-png-info.rs
+++ b/examples/change-png-info.rs
@@ -5,9 +5,9 @@ use std::path::Path;
 pub type BoxResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 fn main() -> BoxResult<()> {
+    // # Decode
     // Read image called test.png in the target folder of the library
     let path = Path::new(r"./target/test.png");
-    //Decode
     // The decoder is a build for reader and can be used to set various decoding options
     // via `Transformations`. The default output transformation is `Transformations::IDENTITY`.
     let decoder = png::Decoder::new(File::open(path)?);
@@ -17,7 +17,7 @@ fn main() -> BoxResult<()> {
     let png_info = reader.info();
     dbg!(png_info);
 
-    //Encode
+    // # Encode
     let path = Path::new(r"./target/test_modified.png");
     let file = File::create(path)?;
     let ref mut w = BufWriter::new(file);
@@ -42,6 +42,7 @@ fn main() -> BoxResult<()> {
     //(0.15000, 0.06000)
     //);
     //encoder.set_source_chromaticities(source_chromaticities);
+
     // Save picture with changed info
     let mut writer = encoder.write_header()?;
     let mut counter = 0u8;

--- a/examples/change-png-info.rs
+++ b/examples/change-png-info.rs
@@ -50,7 +50,7 @@ fn main() -> BoxResult<()> {
         let bytes = &buf[..info.buffer_size()];
         writer.write_image_data(&bytes)?;
         counter += 1;
-        println!("Number of loop:{}", counter);
+        println!("Written frame: {}", counter);
     }
     Ok(())
 }

--- a/examples/change-png-info.rs
+++ b/examples/change-png-info.rs
@@ -1,4 +1,6 @@
-// For reading and opening files
+/// Tests "editing"/re-encoding of an image:
+/// decoding, editing, re-encoding
+
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::Path;

--- a/examples/change-png-info.rs
+++ b/examples/change-png-info.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 pub type BoxResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 fn main() -> BoxResult<()> {
-    //Add image called test.png in the target folder of the library
+    // Read image called test.png in the target folder of the library
     let path = Path::new(r"./target/test.png");
     //Decode
     // The decoder is a build for reader and can be used to set various decoding options

--- a/examples/change-png-info.rs
+++ b/examples/change-png-info.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Lukas Schattenhofer <lukas.schattenhofer@ose-germany.de>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 /// Tests "editing"/re-encoding of an image:
 /// decoding, editing, re-encoding
 


### PR DESCRIPTION
(no need to merge, or maybe squash-merge)

Mostly comment changes in the example.
The code looks good! :-)

Maybe it would make sense to add a doc-comment to the new function `new_with_info`,
explaining what ti does.
To give it a punch - in an additional commit maybe - you could also add a tiny code example within the doc comment,
like it is done here:
https://github.com/hoijui/projvar/blob/02ec1ee27ff072f1a4ac17a4949859ca8f0c2dd0/src/value_conversions.rs#L183
(You could then run/test this code with: `cargo test --release --doc`)
